### PR TITLE
Fix helm URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 var settings *cli.EnvSettings
 
 var (
-	url         = "https://kubernetes-charts.storage.googleapis.com"
+	url         = "https://charts.helm.sh/stable"
 	repoName    = "stable"
 	chartName   = "mysql"
 	releaseName = "mysql-dev"


### PR DESCRIPTION
* Previous URL (https://kubernetes-charts.storage.googleapis.com) does not work.
<img width="973" alt="截圖 2021-04-07 下午3 21 10" src="https://user-images.githubusercontent.com/20109646/113826561-e3ff5100-97b4-11eb-9f2f-b77cb4e105a3.png">
